### PR TITLE
Prepare for Strapi 4.3.x

### DIFF
--- a/strapi-server.js
+++ b/strapi-server.js
@@ -88,7 +88,7 @@ function createMiddleware (ipx) {
 const plugin = {
   register({ strapi }) {
     const ipx = createIPX({
-      dir: `${strapi.dirs?.dist?.public ?? strapi.dirs?.public}/uploads`,
+      dir: `${strapi.dirs?.static?.public ?? strapi.dirs?.dist?.public ?? strapi.dirs?.public}/uploads`,
     })
     const router = new Router();
     const middeware = createMiddleware(ipx)


### PR DESCRIPTION
Allows for the new structure of the `dirs` object. See https://github.com/strapi/strapi/blob/v4.3.0-beta.1/packages/core/strapi/lib/utils/get-dirs.js

You'll otherwise get the following error:
```
IPX Error (File not found (/app/apps/cms/undefined/uploads/thumbnail_logo_white_e635fa69dc.png))
```