### PR TITLE
fix: add conditional for `srcDir` configuration

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -8,7 +8,7 @@ const { createMiddleware } = require('./middleware')
 
 function register({ strapi }) {
   const config = strapi.config.get('plugin.local-image-sharp')
-  config.srcDir = `${strapi.dirs?.static?.public ?? strapi.dirs?.public}/uploads`
+  config.srcDir = `${strapi.dirs?.static?.public ?? strapi.dirs?.public ?? "public"}/uploads`
 
   strapi.log.info(
     `Using Local Image Sharp plugin`


### PR DESCRIPTION
## Description

Resolves an issue where an error would be generated due to an invalid src directory when accessing any media  whatsoever.

Fixes #17

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
