### PR TITLE
feat: allow to configure custom paths

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -118,3 +118,28 @@ module.exports = {
   // ...
 };
 ```
+
+### `paths`
+
+Add custom paths to images if you use more than the default path '/uploads'.
+
+> _By default, '/uploads' is set, to cache all default upload routes._
+
+You can set the paths in `config/plugins.js`:
+
+
+```js [config/plugins.js]
+"use strict";
+
+module.exports = {
+  // ...
+
+  "local-image-sharp": {
+    config: {
+      paths: ['/uploads','/custom'],
+    },
+  },
+
+  // ...
+};
+```

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,12 +2,17 @@
 
 const { pluginConfigSchema } = require('./schema');
 
-module.exports = {
+const config = {
   default: ({ env }) => ({
     cacheDir: env('STRAPI_PLUGIN_LOCAL_IMAGE_SHARP_CACHE_DIR', ''),
     maxAge: 3600,
+    paths: ['/uploads']
   }),
   validator(config) {
     pluginConfigSchema.validateSync(config);
   },
+};
+
+module.exports = {
+  config
 };

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -5,6 +5,7 @@ const yup = require('yup');
 const pluginConfigSchema = yup.object().shape({
   cacheDir: yup.string(),
   maxAge: yup.number().moreThan(0),
+  paths: yup.array().of(yup.string()),
 });
 
 module.exports = {

--- a/src/register.js
+++ b/src/register.js
@@ -2,13 +2,13 @@
 
 const Router = require('@koa/router')
 const { createIPX } = require('ipx')
-const { resolve } = require('path') 
+const { resolve } = require('path')
 const { existsSync, mkdirSync } = require('fs')
 const { createMiddleware } = require('./middleware')
 
 function register({ strapi }) {
   const config = strapi.config.get('plugin.local-image-sharp')
-  config.srcDir = `${strapi.dirs?.static?.public ?? strapi.dirs?.public}/uploads`
+  config.srcDir = strapi.dirs?.static?.public ?? strapi.dirs?.public
 
   strapi.log.info(
     `Using Local Image Sharp plugin`
@@ -36,14 +36,14 @@ function register({ strapi }) {
     );
   }
 
-
-  const ipx = createIPX({
-    dir: config.srcDir,
-  })
   const router = new Router()
-  const middeware = createMiddleware(ipx)
+  config.paths.forEach(path => {
+    const ipx = createIPX({
+      dir: config.srcDir + path,
+    })
 
-  router.get('/uploads/(.*)', middeware)
+    router.get(path + '/(.*)', createMiddleware(ipx))
+  })
 
   strapi.server.use(router.routes())
 }


### PR DESCRIPTION
Allows to set paths in the config to make sure custom paths are recognized.

```
'local-image-sharp': {
   config: {
     cacheDir: '.imgCache',
     paths: ['/uploads', '/legacy']
   },
}
```

Also merge changes from [https://github.com/strapi-community/strapi-plugin-local-image-sharp/pull/27](url)