### PR TITLE
Override "sharp" to latest due to 3 high severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "eslint": "8.20.0",
     "vitepress": "^1.0.0-alpha.35"
   },
+  "overrides": {
+    "sharp": "^0.33.0"
+  },
   "author": {
     "name": "Sacha Stafyniak",
     "email": "sacha@digisquad.io",


### PR DESCRIPTION
npm audit report
sharp <0.32.6
Severity: high
sharp vulnerability in libwebp dependency CVE-2023-4863 - GHSA-54xq-cgqr-rpm3 No fix available node_modules/strapi-plugin-local-image-sharp/node_modules/sharp ipx <=1.0.0-2
Depends on vulnerable versions of sharp
node_modules/strapi-plugin-local-image-sharp/node_modules/ipx strapi-plugin-local-image-sharp *
Depends on vulnerable versions of ipx
node_modules/strapi-plugin-local-image-sharp

3 high severity vulnerabilities